### PR TITLE
Set DALI_APPLICATION_PACKAGE in plugin startup

### DIFF
--- a/NUIPreview/NUIPreview/PreviewCommand.cs
+++ b/NUIPreview/NUIPreview/PreviewCommand.cs
@@ -49,8 +49,7 @@ namespace NUIPreview
             var menuCommandID = new CommandID(CommandSet, CommandId);
             var menuItem = new MenuCommand(this.Execute, menuCommandID);
             commandService.AddCommand(menuItem);
-
-            SetFontsPath();
+            SetupEnvironment();
         }
 
         /// <summary>
@@ -115,11 +114,15 @@ namespace NUIPreview
             }
         }
 
-        private void SetFontsPath()
+        private string GetPackagePath() => Path.GetDirectoryName(Global.GetAssemblyLocalPathFrom(typeof(NUIPreviewPackage)));
+
+        private void SetupEnvironment()
         {
-            var vsixPath = Path.GetDirectoryName(Global.GetAssemblyLocalPathFrom(typeof(NUIPreviewPackage)));
+            var vsixPath = GetPackagePath();
+
             var fontsPath = Path.Combine(vsixPath, "fonts.conf");
             Environment.SetEnvironmentVariable("FONTCONFIG_FILE", fontsPath);
+            Environment.SetEnvironmentVariable("DALI_APPLICATION_PACKAGE", GetPackagePath());
         }
 
         private void PreviewTask()


### PR DESCRIPTION
As reported in https://github.com/dalihub/dali-adaptor/pull/6, there's a crash regarding DALI_APPLICATION_PACKAGE not being set. This patch ensures the environment variable is set to the plugin's directory in its startup.

This will probably raise some issues if the application being _tested_ by the plugin user needs DALI_APPLICATION_PACKAGE to point to a custom directory, but that should be addressed in the future.