### PR TITLE
Accept XAML as a supported language

### DIFF
--- a/NUIPreview/NUIPreview/PreviewWindow.cs
+++ b/NUIPreview/NUIPreview/PreviewWindow.cs
@@ -61,7 +61,7 @@ namespace NUIPreview
 
                 var language = textView.TextBuffer.ContentType.TypeName;
 
-                if (language != null && language == "XML")
+                if (Loader.SupportedLanguages.Contains(language))
                 {
                     var snapshot = textView.TextSnapshot;
 

--- a/NUIPreview/NUIPreview/XamlLoader.cs
+++ b/NUIPreview/NUIPreview/XamlLoader.cs
@@ -21,6 +21,9 @@ namespace Nui.Vsix.Xaml
                 new Converter(),
             });
 
+
+        public static List<string> SupportedLanguages { get; } = new List<string>{ "XAML", "XML" };
+
         protected override IXmlTypeResolver XmlTypeResolver => new XmlTypeXmlTypeResolver(new TypeLocator(Assemblies));
     }
 }


### PR DESCRIPTION
This prevents the the Previewer not updating because of VS editor setting file type as XAML and our Previewer not accepting the language (which is not expected, even because the `Loader` class should and _does_ accept XAML language).