### PR TITLE
Support clr-namespace for namespace declaration as well

### DIFF
--- a/OmniXaml/OmniXaml/TypeLocation/TypeDirectory.cs
+++ b/OmniXaml/OmniXaml/TypeLocation/TypeDirectory.cs
@@ -6,7 +6,7 @@
 
     public class TypeDirectory : ITypeDirectory
     {
-        private const string ClrNamespace = "using:";
+        private static readonly List<string> namespaceDeclarations = new List<string> { "using:", "clr-namespace:" };
         private readonly ISet<XamlNamespace> xamlNamespaces;
 
         public TypeDirectory(IEnumerable<XamlNamespace> xamlNamespaces)
@@ -43,7 +43,7 @@
 
         private static bool IsClrNamespace(string ns)
         {
-            return ns.StartsWith(ClrNamespace);
+            return namespaceDeclarations.Exists(decl => ns.StartsWith(decl));
         }
     }
 }


### PR DESCRIPTION
This patch allows XAML namespace declarations to start with `clr-namespace:` as well as `using:`. This is done by simply considering `clr-namespace:` a valid namespace declaration start.